### PR TITLE
Authorization code grant fails due to case sensitivity issue with the client id

### DIFF
--- a/complete-application/.env
+++ b/complete-application/.env
@@ -1,4 +1,4 @@
-FUSIONAUTH_CLIENT_ID="E9FDB985-9173-4E01-9D73-AC2D60D1DC8E"
+FUSIONAUTH_CLIENT_ID="e9fdb985-9173-4e01-9d73-ac2d60d1dc8e"
 FUSIONAUTH_CLIENT_SECRET="super-secret-secret-that-should-be-regenerated-for-production"
 FUSIONAUTH_SERVER_URL="http://localhost:9011"
 FUSIONAUTH_BROWSER_URL="http://localhost:9011"

--- a/kickstart/kickstart.json
+++ b/kickstart/kickstart.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "applicationId": "E9FDB985-9173-4E01-9D73-AC2D60D1DC8E",
+    "applicationId": "e9fdb985-9173-4e01-9d73-ac2d60d1dc8e",
     "apiKey": "this_really_should_be_a_long_random_alphanumeric_value_but_this_still_works",
     "asymmetricKeyId": "#{UUID()}",
     "newThemeId": "#{UUID()}",


### PR DESCRIPTION
[Issue](https://github.com/FusionAuth/fusionauth-quickstart-php-web/issues/3)